### PR TITLE
Added replica set CLI and intervention

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,6 +89,10 @@ exclude_patterns = []
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"  # 'alabaster'
+# html_logo = "logo.svg"
+# html_theme_options = {
+#     "logo_only": False,
+# }
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/nemesyst
+++ b/nemesyst
@@ -304,11 +304,21 @@ def argument_parser(description=None, cfg_files=None):
                          action="store_true",
                          env_var="N_DB_PASSWORD",
                          help="Set mongodb password.")
+    mongodb.add_argument("--db-intervention",
+                         default=bool(False),
+                         action="store_true",
+                         env_var="N_DB_INTERVENTION",
+                         help="Manual intervention during database setup.")
     mongodb.add_argument("--db-authentication",
                          default=str("SCRAM-SHA-1"),
                          type=str,
                          env_var="N_DB_AUTHENTICATION",
                          help="Set the mongodb authentication method.")
+    mongodb.add_argument("--db-replica-set-name",
+                         default=None,
+                         type=str,
+                         env_var="N_DB_REPLICA_SET_NAME",
+                         help="Set the name for the replica set to use.")
     mongodb.add_argument("--db-user-role",
                          default=str("readWrite"),
                          type=str,

--- a/nemesyst_core/mongo.py
+++ b/nemesyst_core/mongo.py
@@ -43,12 +43,14 @@ class Mongo(object):
         defaults = {
             "db_user_name": "groot",
             "db_password": "iamgroot",
+            "db_intervention": False,
             "db_authentication": "SCRAM-SHA-1",
             "db_user_role": "readWrite",
             "db_ip": "localhost",
             "db_bind_ip": ["localhost"],
             "db_name": "nemesyst",
             "db_collection_name": "test",
+            "db_replica_set_name": None,
             "db_port": "27017",
             # "db_url": "mongodb://localhost:27017/", # this is auto generated
             "db_url": None,
@@ -114,6 +116,10 @@ class Mongo(object):
         time.sleep(2)
         # connect to db in local scope
         self._addUser()
+        # manual intervention if desired
+        if(self.args["db_intervention"]):
+            # INITIATING MANUAL SUPERPOWERS
+            self.login(db_ip="localhost")
         # close the unauth db
         self.stop()
 
@@ -209,7 +215,7 @@ class Mongo(object):
                              "return": None}
 
     def start(self, db_ip=None, db_port=None, db_path=None, db_log_path=None,
-              db_log_name=None, db_cursor_timeout=None):
+              db_log_name=None, db_cursor_timeout=None, db_replica_set_name=None):
         """Launch an on machine database with authentication.
 
         :param db_ip: List of IPs to accept connectiongs from.
@@ -236,6 +242,8 @@ class Mongo(object):
             self.args["db_log_name"]
         db_cursor_timeout = db_cursor_timeout if db_cursor_timeout is not \
             None else self.args["db_cursor_timeout"]
+        db_replica_set_name = db_replica_set_name if db_replica_set_name is \
+            not None else self.args["db_replica_set_name"]
 
         self.args["pylog"]("Starting mongodb: auth=",
                            str(self.args["db_authentication"]))
@@ -250,6 +258,12 @@ class Mongo(object):
             "--auth",
             "--quiet"
         ]
+
+        if(db_replica_set_name is not None):
+            cliArgs += [
+                "--replSet", str(db_replica_set_name)
+            ]
+
         time.sleep(2)
         db_process = subprocess.Popen(cliArgs)
         time.sleep(2)
@@ -260,6 +274,7 @@ class Mongo(object):
                              "db_port": str, "db_path": str,
                              "db_log_path": str, "db_log_name": str,
                              "db_cursor_timeout": int,
+                             "db_replica_set_name"
                              "return": subprocess.Popen}
 
     def stop(self, db_path=None):


### PR DESCRIPTION
Minor change to add manual intervention during setup.
While i was doing this however I think its best to start moving to a MongoDB YAML config file, as it will just get more and more crazy from here to configure MongoDB pureley from CLI, unless we wnat to map every single MongoDB option as a nemesyst option.