### PR TITLE
Fix of mongo.connect working with replica sets

### DIFF
--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -9,7 +9,7 @@ Troubleshooting
 MongoDB/ Serving Issues
 +++++++++++++++++++++++
 
-:Error\: not master and slaveOk=false\::
+:Error\: not master and slaveOk=false:
 
   This error means you have attempted to read from a replica set that is not the master. If you would like to read from SECONDARY-ies/ slaves (anything thats not the PRIMARY) you can:
 
@@ -18,3 +18,7 @@ MongoDB/ Serving Issues
     .. parsed-literal::
 
         `rs.slaveOk() <https://docs.mongodb.com/manual/reference/method/rs.slaveOk/>`_
+
+:pymongo.errors.OperationFailure\: Authentication failed:
+
+  This error means likely means that your authentication credentials are incorrect, you will want to check the values you are passing to pymongo via Nemesyst to ensure they are what you are expecting. In particular pay special attention to Mongo().connect() as it is the life blood of all connections but since the driver is a lazy driver it wont fail until you attempt to use the connection.

--- a/nemesyst
+++ b/nemesyst
@@ -296,7 +296,7 @@ def argument_parser(description=None, cfg_files=None):
     # MongoDB TLS options
     mongodb_tls.add_argument("--db-tls",
                              default=False,
-                             type=bool,
+                             action="store_true",
                              env_var="N_DB_TLS",
                              help="Set connection to mongodb use TLS.")
     mongodb_tls.add_argument("--db-tls-ca-file",

--- a/nemesyst
+++ b/nemesyst
@@ -69,7 +69,9 @@ def cleaner(args_m, i):
                         entry_point=args[
                             "data_cleaner_entry_point"][i])
     db.connect()
+    print("AFTER CONNECT")
     for data in gen:
+        print("DATA", data)
         db.dump(db_collection_name=args["data_collection"][i], data=data)
 
 

--- a/nemesyst
+++ b/nemesyst
@@ -360,6 +360,11 @@ def argument_parser(description=None, cfg_files=None):
                          type=str,
                          env_var="N_DB_AUTHENTICATION",
                          help="Set the mongodb authentication method.")
+    mongodb.add_argument("--db-authentication-database",
+                         default=None,
+                         type=str,
+                         env_var="N_DB_AUTHENTICATION_DATABASE",
+                         help="Override db_name as database to authenticate.")
     mongodb.add_argument("--db-user-role",
                          default=str("readWrite"),
                          type=str,

--- a/nemesyst
+++ b/nemesyst
@@ -69,9 +69,7 @@ def cleaner(args_m, i):
                         entry_point=args[
                             "data_cleaner_entry_point"][i])
     db.connect()
-    print("AFTER CONNECT")
     for data in gen:
-        print("DATA", data)
         db.dump(db_collection_name=args["data_collection"][i], data=data)
 
 

--- a/nemesyst_core/mongo.py
+++ b/nemesyst_core/mongo.py
@@ -46,15 +46,13 @@ class Mongo(object):
             "db_config_path": None,
             "db_intervention": False,
             "db_authentication": "SCRAM-SHA-1",
+            "db_authentication_database": None,
             "db_user_role": "readWrite",
             "db_ip": "localhost",
             "db_bind_ip": ["localhost"],
             "db_name": "nemesyst",
             "db_collection_name": "test",
-            "db_replica_set_name": None,
             "db_port": "27017",
-            # "db_url": "mongodb://localhost:27017/", # this is auto generated
-            "db_url": None,
             "db_path": self.home + "/db",
             "db_log_path": self.home + "/db" + "/log",
             "db_log_name": "mongoLog",
@@ -64,9 +62,11 @@ class Mongo(object):
             "db": None,
             "db_pipeline": None,
             "gfs": None,
-            # TODO: OVERIDE THESE
+
+            "db_replica_set_name": None,
             "db_replica_read_preference": "primary",
             "db_replica_max_staleness": -1,
+
             "db_tls": False,
             "db_tls_ca_file": None,
             "db_tls_certificate_key_file": None,
@@ -76,8 +76,6 @@ class Mongo(object):
         }
         self.args = self._mergeDicts(defaults, args)
         # final adjustments to newly defined dictionary
-        self.args["db_url"] = "mongodb://{0}:{1}/".format(
-            self.args["db_ip"], self.args["db_port"])
         self.args["db_path"] = os.path.abspath(self.args["db_path"])
         self.args["db_log_path"] = os.path.abspath(self.args["db_log_path"])
 
@@ -149,6 +147,7 @@ class Mongo(object):
                             "return": None}
 
     def connect(self, db_ip=None, db_port=None, db_authentication=None,
+                db_authentication_database=None,
                 db_user_name=None, db_password=None, db_name=None,
                 db_replica_set_name=None, db_replica_read_preference=None,
                 db_replica_max_staleness=None, db_tls=None,
@@ -201,6 +200,10 @@ class Mongo(object):
         # authentication mechanism name
         db_authentication = db_authentication if db_authentication is not \
             None else self.args["db_authentication"]
+        # authentication destination db name
+        db_authentication_database = db_authentication_database if\
+            db_authentication_database is not \
+            None else self.args["db_authentication_database"]
         # username
         db_user_name = db_user_name if db_user_name is not None else \
             self.args["db_user_name"]
@@ -248,7 +251,8 @@ class Mongo(object):
         client_args["authMechanism"] = db_authentication
         client_args["username"] = db_user_name
         client_args["password"] = db_password
-        client_args["authSource"] = db_name
+        client_args["authSource"] = db_authentication_database if \
+            db_authentication_database is not None else db_name
 
         # replica set
         client_args["replicaset"] = db_replica_set_name

--- a/nemesyst_core/mongo.py
+++ b/nemesyst_core/mongo.py
@@ -223,7 +223,7 @@ class Mongo(object):
         # to use tls?
         db_tls = db_tls if db_tls is not None else self.args["db_tls"]
         # certificate authoritys certificate file
-        db_tls_ca_file if db_tls_ca_file is not None else \
+        db_tls_ca_file = db_tls_ca_file if db_tls_ca_file is not None else \
             self.args["db_tls_ca_file"]
         # client certificate & key file
         db_tls_certificate_key_file = db_tls_certificate_key_file if \
@@ -270,8 +270,7 @@ class Mongo(object):
 
         db = client[db_name]
         self.args["db"] = db
-        # self.args["gfs"] = gridfs.GridFS(db, collection=db_collection_name)
-        print(db)
+        self.args["gfs"] = gridfs.GridFS(db, collection=db_collection_name)
         return db
 
     connect.__annotations__ = {"db_ip": str,

--- a/nemesyst_core/mongo.py
+++ b/nemesyst_core/mongo.py
@@ -270,7 +270,8 @@ class Mongo(object):
 
         db = client[db_name]
         self.args["db"] = db
-        self.args["gfs"] = gridfs.GridFS(db, collection=db_collection_name)
+        # self.args["gfs"] = gridfs.GridFS(db, collection=db_collection_name)
+        print(db)
         return db
 
     connect.__annotations__ = {"db_ip": str,


### PR DESCRIPTION
Mongo().connect() now works as expected, you of course still need to be very carefull as many things need to be correct to connect to a TLS replica set authenticated MongoDB database.