### PR TITLE
Feature: docker-compose script

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# this is a docker environment file to house more sensitive variables out of source control
+YOUR_ENVIRONMENT_VARIABLE=Please make sure you check the .env file is correct 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # @Author: archer
 # @Date:   2019-09-13T12:52:06+01:00
 # @Last modified by:   archer
-# @Last modified time: 2019-09-13T13:39:26+01:00
+# @Last modified time: 2019-09-13T13:45:28+01:00
 
 
 
@@ -27,4 +27,5 @@ services:
       # - "mongodb-volume:/data/db"
       - /data/db:/data/db
       # local file:docker vm location # this copies over the config file
-      - /etc/mongodb.conf:/etc/mongodb.conf
+      # - /etc/mongodb.conf:/etc/mongodb.conf
+      - examples/configs/mongo_docker.yaml:/etc/mongodb.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # @Author: archer
 # @Date:   2019-09-13T12:52:06+01:00
 # @Last modified by:   archer
-# @Last modified time: 2019-09-13T13:32:33+01:00
+# @Last modified time: 2019-09-13T13:33:41+01:00
 
 
 
@@ -16,7 +16,7 @@ services:
     ports:
       # this maps one of our local ports to one of the containers ones
       # "local-port:container-port"
-      - "65535:27017"
+      - "65530:27017"
     # command:
     #     - "--config"
     #     - "/etc/mongo.conf" # this is the in container path

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # @Author: archer
 # @Date:   2019-09-13T12:52:06+01:00
 # @Last modified by:   archer
-# @Last modified time: 2019-09-13T13:33:41+01:00
+# @Last modified time: 2019-09-13T13:39:26+01:00
 
 
 
@@ -17,9 +17,9 @@ services:
       # this maps one of our local ports to one of the containers ones
       # "local-port:container-port"
       - "65530:27017"
-    # command:
-    #     - "--config"
-    #     - "/etc/mongo.conf" # this is the in container path
+    command:
+      - "--config"
+      - "/etc/mongodb.conf" # this is the in container path
     volumes:
       # this is the location to mount in container and storage for db
       # "volume-name:in-container mount point (not local system):"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+# set environment variables using .env file located in this same directory
+version: "3.7"
+
+services:
+  mongodb:
+    # this is the official image name to use so we dont have to create one
+    image: "mongo"
+    ports:
+      # this maps one of our local ports to one of the containers ones
+      # "local-port:container-port"
+      - "65535:27017"
+    volumes:
+      # this is the location to mount in container and storage for db
+      # "volume-name:in-container mount point (not local system):"
+      # or /local/location:/docker/location
+      # - "mongodb-volume:/data/db"
+      - /data/db:/data/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # @Author: archer
 # @Date:   2019-09-13T12:52:06+01:00
 # @Last modified by:   archer
-# @Last modified time: 2019-09-13T13:23:46+01:00
+# @Last modified time: 2019-09-13T13:30:09+01:00
 
 
 
@@ -10,6 +10,7 @@ version: "3.7"
 
 services:
   mongodb:
+    container_name: mongodb_server
     # this is the official image name to use so we dont have to create one
     image: "mongo"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # @Author: archer
 # @Date:   2019-09-13T12:52:06+01:00
 # @Last modified by:   archer
-# @Last modified time: 2019-09-13T13:45:28+01:00
+# @Last modified time: 2019-09-13T13:48:11+01:00
 
 
 
@@ -28,4 +28,4 @@ services:
       - /data/db:/data/db
       # local file:docker vm location # this copies over the config file
       # - /etc/mongodb.conf:/etc/mongodb.conf
-      - examples/configs/mongo_docker.yaml:/etc/mongodb.conf
+      - ./examples/configs/mongo_docker.yaml:/etc/mongodb.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # @Author: archer
 # @Date:   2019-09-13T12:52:06+01:00
 # @Last modified by:   archer
-# @Last modified time: 2019-09-13T13:30:09+01:00
+# @Last modified time: 2019-09-13T13:32:33+01:00
 
 
 
@@ -17,9 +17,9 @@ services:
       # this maps one of our local ports to one of the containers ones
       # "local-port:container-port"
       - "65535:27017"
-    command:
-        - '--config'
-        - '/etc/mongo.conf' # this is the in container path
+    # command:
+    #     - "--config"
+    #     - "/etc/mongo.conf" # this is the in container path
     volumes:
       # this is the location to mount in container and storage for db
       # "volume-name:in-container mount point (not local system):"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,10 @@
+# @Author: archer
+# @Date:   2019-09-13T12:52:06+01:00
+# @Last modified by:   archer
+# @Last modified time: 2019-09-13T13:23:46+01:00
+
+
+
 # set environment variables using .env file located in this same directory
 version: "3.7"
 
@@ -9,9 +16,14 @@ services:
       # this maps one of our local ports to one of the containers ones
       # "local-port:container-port"
       - "65535:27017"
+    command:
+        - '--config'
+        - '/etc/mongo.conf' # this is the in container path
     volumes:
       # this is the location to mount in container and storage for db
       # "volume-name:in-container mount point (not local system):"
       # or /local/location:/docker/location
       # - "mongodb-volume:/data/db"
       - /data/db:/data/db
+      # local file:docker vm location # this copies over the config file
+      - /etc/mongodb.conf:/etc/mongodb.conf

--- a/docs/source/serving.rst
+++ b/docs/source/serving.rst
@@ -1,12 +1,17 @@
+.. |files-only| replace:: :ref:`section_files-only`
+.. |mongodb| replace:: MongoDB
+.. |yaml| replace:: yaml
 .. |mongo shell| replace:: Mongo shell
 .. |bash shell| replace:: Bash shell
+.. |docker| replace:: Docker
+.. |docker-compose| replace:: Docker-Compose
 .. |troubleshooting| replace:: :ref:`section_ts_mongodb`
 .. _page_serving:
 
 Serving
 =======
 
-Nemesyst uses MongoDB as its primary message passing interface. This page will more elaborate on using Nemesyst with different database setups, debugging, common issues, and any nitty-gritty details that may be necessary to discuss.
+Nemesyst uses |MongoDB| as its primary message passing interface. This page will more elaborate on using Nemesyst with different database setups, debugging, common issues, and any nitty-gritty details that may be necessary to discuss.
 
 .. warning::
   While Nemesyst does support using mongodb.yaml files for complex db setup, care should be taken that Nemesyst is not overriding the values you were expecting in the config files. Things such as the DBs path are almost always overridden along with the port to use by default even if the user has not provided that argument. In future we intend to make it such that hard coded defaults when not overridden by the user, first attempt to look in the mongodb.yaml file before falling back to hard-coded values.
@@ -14,31 +19,65 @@ Nemesyst uses MongoDB as its primary message passing interface. This page will m
 Creating a basic database
 +++++++++++++++++++++++++
 
-disambiguation: we define a basic database as a standalone MongoDB instance with one universal administrator and one read/write user with password authentication.
+Disambiguation: we define a basic database as a standalone |mongodb| instance with one universal administrator and one read/write user with password authentication.
 
-While it is possible it is highly discouraged to use Nemesyst to create the users you require as this is quite complicated to manage and may lead to more problems than its worth compared to simply using something such as:
+While it is possible it is highly discouraged to use Nemesyst to create the users you require as this is quite complicated to manage and may lead to more problems than its worth compared to simply creating a database and adding a user manually using something like the following:
 
-:todo:
+.. _manual_mongodb:
 
-  Include example for basic database creation
+Manual creation of |mongodb|
+----------------------------
+
+:|files-only| creation of database example\::
+
+  .. parsed-literal::
+
+      mongod --config ./examples/configs/basic_mongo_config.yaml
+
+This will create a database with all the |mongodb| defaults as it is an empty |yaml| file.
+If you would instead want a more complex setup please take a look at ``examples/configs/authenticated_replicaset.yaml`` instead, but you will need to generate certificates and keys for this so it is probably a poor place to start but will be what you will want to use in production as a bare minimum security.
+
+|docker-compose| creation of |mongodb|
+--------------------------------------
+
+:|docker-compose|, |files-only| creation of database example\::
+
+  .. parsed-literal::
+
+      docker-compose up
+
+This similar to the :ref:`manual_mongodb` creation uses a simple config file to launch the database. This can be changed in ``docker-compose.yaml``.
+At this point you will need to connect to the running |mongodb| instance to create your main administrator user, with "userAdminAnyDatabase" role.
+After this you can use the following to close the docker container with the database:
+
+:|docker-compose|, |files-only|, closing |docker-compose| database example\::
+
+  .. parsed-literal::
+
+      docker-compose down
+
+.. note::
+  Don't worry we set our docker-compose.yaml to save its files in ``/data/db`` so they are persistent between runs of docker-compose. If you need to delete the |mongodb| database that is where you can find them.
+
+.. _connecting_mongodb:
 
 Connecting to a running database
-++++++++++++++++++++++++++++++++
+--------------------------------
 
-To be able to fine tune, create users, update etc it will be necessary to connect to MongoDB in one form or another. Nemesyst can help you log in or you can do it manually.
+To be able to fine tune, create users, update etc it will be necessary to connect to |mongodb| in one form or another. Nemesyst can help you log in or you can do it manually.
 
  .. note::
    If there is no `userAdmin or userAdminAnyDatabase <https://docs.mongodb.com/manual/reference/built-in-roles/#userAdmin>`_ then unless expressly configured there will be a localhost exception which will allow you to log in and create this user. If this user exists the localhost exception will close. Please ensure you configure this user as they can grant any role or rights to anyone and would be a major security concern along with making it very difficult to admin your database.
 
 Nemesyst
---------
+********
 
 :todo:
 
-  Include instructions for logging into mongodb from Nemesyst.
+  Include instructions for logging into |mongodb| from Nemesyst.
 
 Mongo
------
+*****
 
 To connect to an non-sharded database with autnentication but no TLS/SSL:
 
@@ -55,6 +94,28 @@ To connect to a slightly more complicated scenario with authentication, TLS, and
   .. parsed-literal::
 
       mongo HOSTNAME:PORT -u USERNAME --authenticationDatabase DATABASENAME --tls --tlsCAFile PATHTOCAFILE --tlsCertificateKeyFile PATHTOCERTKEYFILE
+
+Creating database users
+-----------------------
+
+You will absolutely need a user with at least "userAdminAnyDatabase" role.
+Connect to the running database see :ref:`connecting_mongodb`.
+
+:|mongo shell| create a new role-less user\::
+
+  .. parsed-literal::
+
+    db.createUser({user: "USERNAME", pwd: passwordPrompt(), roles: []})
+
+:|mongo shell| grant role to existing user example\::
+
+  .. parsed-literal::
+
+    db.grantRolesToUser(
+    "USERNAME",
+    [
+      { role: "userAdminAnyDatabase", db: "admin" }
+    ])
 
 From basic database to replica sets
 +++++++++++++++++++++++++++++++++++

--- a/examples/configs/basic_mongo_config.yaml
+++ b/examples/configs/basic_mongo_config.yaml
@@ -1,0 +1,4 @@
+# @Author: archer
+# @Date:   2019-09-13T13:44:10+01:00
+# @Last modified by:   archer
+# @Last modified time: 2019-09-13T13:44:10+01:00

--- a/examples/configs/mongo_docker.yaml
+++ b/examples/configs/mongo_docker.yaml
@@ -1,0 +1,4 @@
+# @Author: archer
+# @Date:   2019-09-13T13:44:10+01:00
+# @Last modified by:   archer
+# @Last modified time: 2019-09-13T13:44:10+01:00

--- a/nemesyst_core/mongo.py
+++ b/nemesyst_core/mongo.py
@@ -617,15 +617,15 @@ class Mongo(object):
     def __iter__(self):
         """Iterate through housed dictionary, for looping."""
         raise NotImplementedError("iter() is not yet implemented")
-        self.db.connect()
-        cursor = self.db.getData(pipeline=self.getPipe(
-            self.args["pipeline"]), db_collection_name=self.args["coll"])
-
-        while(cursor.alive):
-            try:
-                yield self._nextBatch(cursor)
-            except StopIteration:
-                return
+        # self.db.connect()
+        # cursor = self.db.getData(pipeline=self.getPipe(
+        #     self.args["pipeline"]), db_collection_name=self.args["coll"])
+        #
+        # while(cursor.alive):
+        #     try:
+        #         yield self._nextBatch(cursor)
+        #     except StopIteration:
+        #         return
 
     __iter__.__annotations__ = {"return": any}
 


### PR DESCRIPTION
We have added a new docker-compose script to start the database in /data/db and open on port 65535, and to copy our example mongodb.yaml file into it for better configuration.

The documentation page on serving has been updated as such, and has also been extended while we were there.